### PR TITLE
Add "torch_stft" support

### DIFF
--- a/asteroid_filterbanks/__init__.py
+++ b/asteroid_filterbanks/__init__.py
@@ -1,8 +1,9 @@
+from .enc_dec import Filterbank, Encoder, Decoder
 from .analytic_free_fb import AnalyticFreeFB
 from .free_fb import FreeFB
 from .param_sinc_fb import ParamSincFB
 from .stft_fb import STFTFB
-from .enc_dec import Filterbank, Encoder, Decoder
+from .torch_stft_fb import TorchSTFTFB
 from .griffin_lim import griffin_lim, misi
 from .multiphase_gammatone_fb import MultiphaseGammatoneFB
 from .melgram_fb import MelGramFB
@@ -110,6 +111,7 @@ free = FreeFB
 analytic_free = AnalyticFreeFB
 param_sinc = ParamSincFB
 stft = STFTFB
+torch_stft = TorchSTFTFB
 multiphase_gammatone = mpgtf = MultiphaseGammatoneFB
 
 # For the docs
@@ -119,6 +121,7 @@ __all__ = [
     "Decoder",
     "FreeFB",
     "STFTFB",
+    "TorchSTFTFB",
     "AnalyticFreeFB",
     "ParamSincFB",
     "MultiphaseGammatoneFB",

--- a/tests/jit_filterbanks_test.py
+++ b/tests/jit_filterbanks_test.py
@@ -2,12 +2,11 @@ import torch
 import pytest
 from torch.testing import assert_allclose
 from asteroid_filterbanks import make_enc_dec
-from asteroid_filterbanks.torch_stft_fb import TorchSTFTFB
 
 
 @pytest.mark.parametrize(
     "filter_bank_name",
-    ("free", "stft", "analytic_free", "param_sinc", TorchSTFTFB),
+    ("free", "stft", "torch_stft", "analytic_free", "param_sinc"),
 )
 @pytest.mark.parametrize(
     "inference_data",
@@ -23,7 +22,7 @@ from asteroid_filterbanks.torch_stft_fb import TorchSTFTFB
 )
 def test_jit_filterbanks_enc(filter_bank_name, inference_data):
     n_filters = 32
-    if filter_bank_name == TorchSTFTFB:
+    if filter_bank_name == "torch_stft":
         kernel_size = n_filters
     else:
         kernel_size = n_filters // 2
@@ -41,7 +40,7 @@ def test_jit_filterbanks_enc(filter_bank_name, inference_data):
 
 @pytest.mark.parametrize(
     "filter_bank_name",
-    ("free", "stft", "analytic_free", "param_sinc", TorchSTFTFB),
+    ("free", "stft", "torch_stft", "analytic_free", "param_sinc"),
 )
 @pytest.mark.parametrize(
     "inference_data",
@@ -79,7 +78,7 @@ class DummyModel(torch.nn.Module):
         **fb_kwargs,
     ):
         super().__init__()
-        if fb_name == TorchSTFTFB:
+        if fb_name == "torch_stft":
             n_filters = kernel_size
         encoder, decoder = make_enc_dec(
             fb_name, kernel_size=kernel_size, n_filters=n_filters, stride=stride, **fb_kwargs


### PR DESCRIPTION
Make it available as a string too. Or is there a reason it is only accessible using class name?