### PR TITLE
Migrate away from removed numpy.math

### DIFF
--- a/asteroid_filterbanks/multiphase_gammatone_fb.py
+++ b/asteroid_filterbanks/multiphase_gammatone_fb.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import torch
 from .enc_dec import Filterbank
@@ -87,8 +88,8 @@ def gammatone_impulse_response(samplerate_hz, len_sec, center_freq_hz, phase_shi
     """ Generate single parametrized gammatone filter """
     p = 2  # filter order
     erb = 24.7 + 0.108 * center_freq_hz  # equivalent rectangular bandwidth
-    divisor = (np.pi * np.math.factorial(2 * p - 2) * np.power(2, float(-(2 * p - 2)))) / np.square(
-        np.math.factorial(p - 1)
+    divisor = (np.pi * math.factorial(2 * p - 2) * np.power(2, float(-(2 * p - 2)))) / np.square(
+        math.factorial(p - 1)
     )
     b = erb / divisor  # bandwidth parameter
     a = 1.0  # amplitude. This is varied later by the normalization process.


### PR DESCRIPTION
This was just a wrapper for the python stdlib math anyway, so nothing was lost. Also I checked and numpy does not provide a factorial function.

Fixes the following series of errors when running with numpy 2.2.0:

```
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_lowdim[fb_config0-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_lowdim[fb_config1-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_lowdim[fb_config2-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_lowdim[fb_config3-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_all_dims[fb_config0-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_all_dims[fb_config1-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_all_dims[fb_config2-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_def_and_forward_all_dims[fb_config3-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[2-fb_config0-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[2-fb_config1-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[2-fb_config2-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[2-fb_config3-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[3-fb_config0-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[3-fb_config1-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[3-fb_config2-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[3-fb_config3-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[4-fb_config0-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[4-fb_config1-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[4-fb_config2-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_fb_forward_multichannel[4-fb_config3-MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
FAILED tests/filterbanks_test.py::test_pinv_of[MultiphaseGammatoneFB] - AttributeError: module 'numpy' has no attribute 'math'. Did you mean: 'emath'?
======= 21 failed, 643 passed, 1494 deselected, 1091 warnings in 18.39s ========
```